### PR TITLE
avoid missleading logline during kube goclient initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,16 +79,26 @@ var alertStore []alert
 const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 
 func initKubeClient(kubeconfig *string) *kubernetes.Clientset {
+	var config *rest.Config
+	var err error
 
-	//use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	// Try in-cluster config first
+	config, err = rest.InClusterConfig()
 	if err != nil {
-		log.Fatal("Could not read k8s configuration: %s", zap.String("error", err.Error()))
+		log.Debug("In-cluster configuration not available, trying kubeconfig file")
+		// Use kubeconfig file
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			log.Fatal("Could not create k8s configuration", zap.String("error", err.Error()))
+		}
+		log.Info("Using kubeconfig file for cluster access")
+	} else {
+		log.Info("Using in-cluster configuration")
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Fatal("Could not create k8s client: %s", zap.String("error", err.Error()))
+		log.Fatal("Could not create k8s client", zap.String("error", err.Error()))
 	}
 
 	return clientset


### PR DESCRIPTION
If openfero is run in-cluster then it logs the following lines. This causes irritation for the user and should therefore be avoided.

```
W0211 12:35:20.466589       1 client_config.go:667] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
```