### PR TITLE
fix(helm): correct YAML indentation in PodDisruptionBudget and RoleBi…

### DIFF
--- a/charts/openfero/templates/poddisruptionbudget.yaml
+++ b/charts/openfero/templates/poddisruptionbudget.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ include "openfero.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-    minAvailable: 1
-    selector:
-      matchLabels:
+  minAvailable: 1
+  selector:
+    matchLabels:
       {{- include "openfero.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/openfero/templates/rolebinding-read-jobs.yaml
+++ b/charts/openfero/templates/rolebinding-read-jobs.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ include "openfero.fullname" . }}-job-definitions-viewers
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ include "openfero.labels" . | nindent 4 }}
+    {{- include "openfero.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
…nding

- Fix PodDisruptionBudget spec fields indentation from 4 to 2 spaces
- Fix RoleBinding template formatting (remove empty line before labels)
- Ensure all generated Kubernetes YAML is valid and follows standards

Resolves invalid YAML generation that would cause kubectl validation failures.